### PR TITLE
Improve compatibility of interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Change Log
+
+### 1.1.0
+
+- Allow 'context' replacements in log messages to conform either to Symfony Translation component conventions (e.g. `"%key%", ['%key%' => 'value']`) or to Symfony ConsoleLogger conventions (e.g. `"{key}", ['key' => 'value']`). Simple keys that begin and end with alphanumeric characters are still wrapped in `{}`, whereas other keys are used as-is.
+
+### 1.0.3
+
+- README improvements
+- Run code sniffer prior to tests
+
+### 1.0.2
+
+- Remove unused components from composer.json
+
+### 1.0.1
+
+- Fix branch alias

--- a/build/logs/clover.xml
+++ b/build/logs/clover.xml
@@ -1,0 +1,190 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<coverage generated="1482349218">
+  <project timestamp="1482349218">
+    <package name="Consolidation\Log">
+      <file name="/Users/ganderson/local/consolidation/log/src/LogOutputStyler.php">
+        <class name="LogOutputStyler" namespace="Consolidation\Log">
+          <metrics methods="6" coveredmethods="3" conditionals="0" coveredconditionals="0" statements="24" coveredstatements="21" elements="30" coveredelements="24"/>
+        </class>
+        <line num="46" type="method" name="__construct" crap="1" count="1"/>
+        <line num="48" type="stmt" count="1"/>
+        <line num="49" type="stmt" count="1"/>
+        <line num="50" type="stmt" count="1"/>
+        <line num="55" type="method" name="defaultStyles" crap="1" count="1"/>
+        <line num="57" type="stmt" count="1"/>
+        <line num="63" type="method" name="style" crap="5.03" count="1"/>
+        <line num="65" type="stmt" count="1"/>
+        <line num="66" type="stmt" count="1"/>
+        <line num="67" type="stmt" count="1"/>
+        <line num="68" type="stmt" count="1"/>
+        <line num="69" type="stmt" count="1"/>
+        <line num="70" type="stmt" count="1"/>
+        <line num="72" type="stmt" count="1"/>
+        <line num="73" type="stmt" count="0"/>
+        <line num="74" type="stmt" count="1"/>
+        <line num="77" type="stmt" count="1"/>
+        <line num="83" type="method" name="wrapFormatString" crap="2.15" count="1"/>
+        <line num="85" type="stmt" count="1"/>
+        <line num="86" type="stmt" count="1"/>
+        <line num="88" type="stmt" count="0"/>
+        <line num="95" type="method" name="formatMessageByLevel" crap="1" count="1"/>
+        <line num="97" type="stmt" count="1"/>
+        <line num="98" type="stmt" count="1"/>
+        <line num="104" type="method" name="formatMessage" crap="3.07" count="1"/>
+        <line num="106" type="stmt" count="1"/>
+        <line num="107" type="stmt" count="0"/>
+        <line num="109" type="stmt" count="1"/>
+        <line num="110" type="stmt" count="1"/>
+        <line num="113" type="stmt" count="1"/>
+        <metrics loc="115" ncloc="94" classes="1" methods="6" coveredmethods="3" conditionals="0" coveredconditionals="0" statements="24" coveredstatements="21" elements="30" coveredelements="24"/>
+      </file>
+      <file name="/Users/ganderson/local/consolidation/log/src/Logger.php">
+        <class name="Logger" namespace="Consolidation\Log">
+          <metrics methods="16" coveredmethods="9" conditionals="0" coveredconditionals="0" statements="62" coveredstatements="48" elements="78" coveredelements="57"/>
+        </class>
+        <line num="63" type="method" name="__construct" crap="1" count="35"/>
+        <line num="65" type="stmt" count="35"/>
+        <line num="67" type="stmt" count="35"/>
+        <line num="68" type="stmt" count="35"/>
+        <line num="69" type="stmt" count="35"/>
+        <line num="70" type="stmt" count="35"/>
+        <line num="72" type="method" name="setLogOutputStyler" crap="1" count="35"/>
+        <line num="74" type="stmt" count="35"/>
+        <line num="75" type="stmt" count="35"/>
+        <line num="76" type="stmt" count="35"/>
+        <line num="77" type="stmt" count="35"/>
+        <line num="78" type="stmt" count="35"/>
+        <line num="80" type="method" name="getLogOutputStyler" crap="2.15" count="35"/>
+        <line num="82" type="stmt" count="35"/>
+        <line num="83" type="stmt" count="0"/>
+        <line num="85" type="stmt" count="35"/>
+        <line num="88" type="method" name="getOutputStream" crap="1" count="35"/>
+        <line num="90" type="stmt" count="35"/>
+        <line num="93" type="method" name="getErrorStream" crap="3.04" count="35"/>
+        <line num="95" type="stmt" count="35"/>
+        <line num="96" type="stmt" count="35"/>
+        <line num="97" type="stmt" count="35"/>
+        <line num="98" type="stmt" count="0"/>
+        <line num="100" type="stmt" count="35"/>
+        <line num="102" type="stmt" count="35"/>
+        <line num="105" type="method" name="setOutputStream" crap="2" count="0"/>
+        <line num="107" type="stmt" count="0"/>
+        <line num="108" type="stmt" count="0"/>
+        <line num="109" type="stmt" count="0"/>
+        <line num="111" type="method" name="setErrorStream" crap="2" count="0"/>
+        <line num="113" type="stmt" count="0"/>
+        <line num="114" type="stmt" count="0"/>
+        <line num="115" type="stmt" count="0"/>
+        <line num="117" type="method" name="getOutputStreamWrapper" crap="6" count="0"/>
+        <line num="119" type="stmt" count="0"/>
+        <line num="120" type="stmt" count="0"/>
+        <line num="122" type="stmt" count="0"/>
+        <line num="125" type="method" name="getErrorStreamWrapper" crap="2" count="35"/>
+        <line num="127" type="stmt" count="35"/>
+        <line num="128" type="stmt" count="35"/>
+        <line num="130" type="stmt" count="35"/>
+        <line num="133" type="method" name="getOutputStreamForLogLevel" crap="3.33" count="35"/>
+        <line num="138" type="stmt" count="35"/>
+        <line num="139" type="stmt" count="0"/>
+        <line num="141" type="stmt" count="35"/>
+        <line num="147" type="method" name="log" crap="5.39" count="35"/>
+        <line num="155" type="stmt" count="35"/>
+        <line num="156" type="stmt" count="0"/>
+        <line num="160" type="stmt" count="35"/>
+        <line num="161" type="stmt" count="0"/>
+        <line num="167" type="stmt" count="35"/>
+        <line num="170" type="stmt" count="35"/>
+        <line num="171" type="stmt" count="31"/>
+        <line num="173" type="stmt" count="35"/>
+        <line num="178" type="method" name="doLog" crap="2" count="31"/>
+        <line num="180" type="stmt" count="31"/>
+        <line num="181" type="stmt" count="31"/>
+        <line num="182" type="stmt" count="31"/>
+        <line num="184" type="stmt" count="31"/>
+        <line num="186" type="stmt" count="31"/>
+        <line num="188" type="stmt" count="31"/>
+        <line num="194" type="stmt" count="31"/>
+        <line num="196" type="method" name="success" crap="1" count="1"/>
+        <line num="198" type="stmt" count="1"/>
+        <line num="199" type="stmt" count="1"/>
+        <line num="256" type="method" name="interpolate" crap="1" count="31"/>
+        <line num="259" type="stmt" count="31"/>
+        <line num="262" type="stmt" count="31"/>
+        <line num="272" type="method" name="interpolationReplacements" crap="5" count="31"/>
+        <line num="275" type="stmt" count="31"/>
+        <line num="276" type="stmt" count="31"/>
+        <line num="281" type="stmt" count="3"/>
+        <line num="282" type="stmt" count="3"/>
+        <line num="285" type="stmt" count="31"/>
+        <line num="296" type="method" name="interpolationKey" crap="3" count="2"/>
+        <line num="298" type="stmt" count="2"/>
+        <line num="299" type="stmt" count="1"/>
+        <line num="301" type="stmt" count="1"/>
+        <metrics loc="303" ncloc="176" classes="1" methods="16" coveredmethods="9" conditionals="0" coveredconditionals="0" statements="62" coveredstatements="48" elements="78" coveredelements="57"/>
+      </file>
+      <file name="/Users/ganderson/local/consolidation/log/src/SymfonyLogOutputStyler.php">
+        <class name="SymfonyLogOutputStyler" namespace="Consolidation\Log">
+          <metrics methods="9" coveredmethods="5" conditionals="0" coveredconditionals="0" statements="15" coveredstatements="8" elements="24" coveredelements="13"/>
+        </class>
+        <line num="18" type="method" name="defaultStyles" crap="2" count="0"/>
+        <line num="20" type="stmt" count="0"/>
+        <line num="23" type="method" name="style" crap="1" count="5"/>
+        <line num="25" type="stmt" count="5"/>
+        <line num="28" type="method" name="createOutputWrapper" crap="1" count="5"/>
+        <line num="33" type="stmt" count="5"/>
+        <line num="36" type="method" name="log" crap="2" count="0"/>
+        <line num="38" type="stmt" count="0"/>
+        <line num="39" type="stmt" count="0"/>
+        <line num="41" type="method" name="success" crap="1" count="1"/>
+        <line num="43" type="stmt" count="1"/>
+        <line num="44" type="stmt" count="1"/>
+        <line num="46" type="method" name="error" crap="2" count="0"/>
+        <line num="48" type="stmt" count="0"/>
+        <line num="49" type="stmt" count="0"/>
+        <line num="51" type="method" name="warning" crap="1" count="1"/>
+        <line num="53" type="stmt" count="1"/>
+        <line num="54" type="stmt" count="1"/>
+        <line num="56" type="method" name="note" crap="1" count="3"/>
+        <line num="58" type="stmt" count="3"/>
+        <line num="59" type="stmt" count="3"/>
+        <line num="61" type="method" name="caution" crap="2" count="0"/>
+        <line num="63" type="stmt" count="0"/>
+        <line num="64" type="stmt" count="0"/>
+        <metrics loc="65" ncloc="51" classes="1" methods="9" coveredmethods="5" conditionals="0" coveredconditionals="0" statements="15" coveredstatements="8" elements="24" coveredelements="13"/>
+      </file>
+      <file name="/Users/ganderson/local/consolidation/log/src/UnstyledLogOutputStyler.php">
+        <class name="UnstyledLogOutputStyler" namespace="Consolidation\Log">
+          <metrics methods="11" coveredmethods="8" conditionals="0" coveredconditionals="0" statements="12" coveredstatements="9" elements="23" coveredelements="17"/>
+        </class>
+        <line num="12" type="method" name="createOutputWrapper" crap="1" count="30"/>
+        <line num="14" type="stmt" count="30"/>
+        <line num="20" type="method" name="defaultStyles" crap="2" count="0"/>
+        <line num="22" type="stmt" count="0"/>
+        <line num="28" type="method" name="style" crap="1" count="25"/>
+        <line num="30" type="stmt" count="25"/>
+        <line num="36" type="method" name="write" crap="1" count="26"/>
+        <line num="38" type="stmt" count="26"/>
+        <line num="39" type="stmt" count="26"/>
+        <line num="44" type="method" name="log" crap="2" count="0"/>
+        <line num="46" type="stmt" count="0"/>
+        <line num="52" type="method" name="success" crap="1" count="6"/>
+        <line num="54" type="stmt" count="6"/>
+        <line num="60" type="method" name="error" crap="1" count="7"/>
+        <line num="62" type="stmt" count="7"/>
+        <line num="68" type="method" name="warning" crap="1" count="5"/>
+        <line num="70" type="stmt" count="5"/>
+        <line num="76" type="method" name="note" crap="1" count="8"/>
+        <line num="78" type="stmt" count="8"/>
+        <line num="84" type="method" name="caution" crap="2" count="0"/>
+        <line num="86" type="stmt" count="0"/>
+        <line num="93" type="method" name="formatMessageByLevel" crap="1" count="25"/>
+        <line num="95" type="stmt" count="25"/>
+        <metrics loc="97" ncloc="63" classes="1" methods="11" coveredmethods="8" conditionals="0" coveredconditionals="0" statements="12" coveredstatements="9" elements="23" coveredelements="17"/>
+      </file>
+    </package>
+    <file name="/Users/ganderson/local/consolidation/log/src/LogOutputStylerInterface.php">
+      <metrics loc="105" ncloc="27" classes="0" methods="0" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="0" coveredstatements="0" elements="0" coveredelements="0"/>
+    </file>
+    <metrics files="5" loc="685" ncloc="411" classes="4" methods="42" coveredmethods="25" conditionals="0" coveredconditionals="0" statements="113" coveredstatements="86" elements="155" coveredelements="111"/>
+  </project>
+</coverage>

--- a/tests/testLogMethods.php
+++ b/tests/testLogMethods.php
@@ -51,4 +51,16 @@ class LogMethodTests extends \PHPUnit_Framework_TestCase
     $outputText = rtrim($this->output->fetch());
     $this->assertEquals(' [success] It worked!', $outputText);
   }
+
+  function testInterpolationBackwardsCompatiblityMode() {
+    $this->logger->error('The {noun} is missing.', ['noun' => 'airplane']);
+    $outputText = rtrim($this->output->fetch());
+    $this->assertEquals(' [error] The airplane is missing.', $outputText);
+  }
+
+  function testInterpolation() {
+    $this->logger->error('The %noun% is missing.', ['%noun%' => 'airplane']);
+    $outputText = rtrim($this->output->fetch());
+    $this->assertEquals(' [error] The airplane is missing.', $outputText);
+  }
 }


### PR DESCRIPTION
Allow 'context' replacements in log messages to conform either to Symfony Translation component conventions or Symfony ConsoleLogger conventions.